### PR TITLE
Dockerize npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG BUILD_CONTEXT
 
 # Run to build the theme
 # docker build -t idc_theme_build .
-# docker run --rm -v $(pwd):/usr/src/project islandora_starter_theme bash -c "cd js && bash autobuild.sh"
+# docker run --rm -v $(pwd):/usr/src/project islandora_starter_theme bash -c "bash autobuild.sh"
 
 RUN npm install -g gulp@4.0.2 gulp-cli
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:10.19.0 as build
 ARG BUILD_CONTEXT
 
 # Run to build the theme
-# docker build -t idc_theme_build .
+# docker build -t islandora_starter_theme .
 # docker run --rm -v $(pwd):/usr/src/project islandora_starter_theme bash -c "bash autobuild.sh"
 
 RUN npm install -g gulp@4.0.2 gulp-cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:10.19.0 as build
+ARG BUILD_CONTEXT
+
+# Run to build the theme
+# docker build -t idc_theme_build .
+# docker run --rm -v $(pwd):/usr/src/project islandora_starter_theme bash -c "cd js && bash autobuild.sh"
+
+RUN npm install -g gulp@4.0.2 gulp-cli
+
+RUN mkdir -p /usr/src/project
+WORKDIR /usr/src/project

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ config/install/color.theme.islandora_starter_theme.yml
 ## CSS
 Comes with precomiled SCSS files. 
 
-### To compile:
+### To compile locally:
 You will need nodejs, npm, gulp, gulp-cli, sass installed.
 ```
 $ cd codebase/web/themes/contrib/islandora_starter_theme
@@ -26,4 +26,11 @@ v10.19.0
 ~/islandora_starter_theme# gulp --version
 CLI version: 2.3.0
 Local version: 4.0.2
+```
+
+### To compile with Docker:
+You will start a Docker container that includes nodejs, npm, gulp, gulp-cli, sass already installed.
+```shell
+docker build -t idc_theme_build .
+docker run --rm -v $(pwd):/usr/src/project islandora_starter_theme bash -c "bash autobuild.sh"
 ```

--- a/autobuild.sh
+++ b/autobuild.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+npm install
+gulp styles


### PR DESCRIPTION
This adds the ability to build with Docker instead of installing specific versions of Node & gulp directly onto the host machine.

The readme has instructions on how to run it.

- - - 
I wasn't sure if I should add instructions to make this build simpler on isle-dc. This is what I left off of the README. If you find it useful, feel free to add it back.


--- README.md---
### Add Custom function to isle-dc to compile quickly
Add the following to `custom.Makefile` in your isle-dc directory (add the file if it doesn't exist)
```Makefile
# Compile the theme
.PHONY: theme-compile
.SILENT: theme-compile
theme-compile:
	-docker rmi $(docker images | grep 'islandora_theme_build')
	cd $(shell pwd)/codebase/web/themes/contrib/islandora_starter_theme && docker build -t islandora_theme_build .
	docker run --rm -v $(shell pwd)/codebase/web/themes/contrib/islandora_starter_theme:/usr/src/project islandora_theme_build bash -c "bash autobuild.sh"
	docker-compose exec -T drupal bash -lc "drush cc theme-registry"
 ```